### PR TITLE
Update release promote command in setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -43,4 +43,5 @@ gcloud beta deploy releases promote \
     --release="release-${RELEASE_TIMESTAMP}" \
     --delivery-pipeline=cloud-run-pipeline \
     --region=${REGION} \
+    --to-target=qa-env \
     --quiet


### PR DESCRIPTION
The --to-target parameter was added to avoid an error.

ERROR: (gcloud.beta.deploy.releases.promote) This release is not deployed to a target in the active delivery pipeline. Include the --to-target parameter to indicate which target to promote to.